### PR TITLE
Linux環境でmakeする時に問題となる箇所を修正

### DIFF
--- a/src/ImamoeFc.asm
+++ b/src/ImamoeFc.asm
@@ -20,7 +20,7 @@
 .include "sound.asm"
 .include "String.asm"
 .include "boss.asm"
-.include "button.asm"
+.include "Button.asm"
 
 .include "scene_title.asm"
 .include "scene_introduction.asm"

--- a/src/makefile
+++ b/src/makefile
@@ -11,15 +11,15 @@ OBJECTS	=	$(CSOURCES:.c=.o) $(ASMSOURCES:.asm=.o)
 LIBRARIES =
 #-------------------------------------------------------------------------------
 all :	$(OBJECTS) $(LIBRARIES)
-	LD65 -o ‚¢‚Ü‚¢‚¿–G‚¦‚È‚¢–º.nes --config ImamoeFc.cfg --obj $(OBJECTS) -m ImamoeFc.map
+	$(LD65) -o ImamoeFc.nes --config ImamoeFc.cfg --obj $(OBJECTS) -m ImamoeFc.map
 
 .SUFFIXES : .asm .o
 
 .c.o :
-	CL65 -t none -o $*.o -c -O $*.c
+	$(CL65) -t none -o $*.o -c -O $*.c
 
 .asm.o :
-	CL65 -t none -o $*.o -c $*.asm
+	$(CL65) -t none -o $*.o -c $*.asm
 
 clean :
 	del *.smc


### PR DESCRIPTION
- Fixed an issue in case-sensitive environments.
- Consideration for environments where CP932 may be garbled.
- Fixed some places in the makefile where variables were not expanded.
Fixes amarida/ImamoeFc#1